### PR TITLE
Avoid random time value on each deserialization

### DIFF
--- a/app/src/main/java/uz/yt/ofd/android/lib/codec/BCDDateTime.java
+++ b/app/src/main/java/uz/yt/ofd/android/lib/codec/BCDDateTime.java
@@ -63,6 +63,7 @@ public class BCDDateTime {
         cal.set(Calendar.HOUR_OF_DAY, (int) hour);
         cal.set(Calendar.MINUTE, (int) min);
         cal.set(Calendar.SECOND, (int) sec);
+        cal.set(Calendar.MILLISECOND, 0);
         return cal.getTime();
     }
 


### PR DESCRIPTION
Milliseconds field value is equal to current millis when Calendar.getInstance() is invoked. It's better to reset millis to 0 to have consistent unix time value on each deserialization